### PR TITLE
fix: four bugs in integrate and exon_fasta_to_twobit modules

### DIFF
--- a/src/python/modules/constants.py
+++ b/src/python/modules/constants.py
@@ -357,13 +357,6 @@ nextflow.enable.dsl=2
 
 params.joblist = 'NONE'  // file containing jobs
 
-if (params.joblist == "NONE"){{
-    println("Usage: nextflow execute_joblist.nf  --joblist [joblist file] -c [config file]")
-    System.exit(2);
-}}
-
-lines = Channel.fromPath(params.joblist).splitText()
-
 process execute_jobs {{
 
     errorStrategy 'retry'
@@ -380,6 +373,11 @@ process execute_jobs {{
 }}
 
 workflow {{
+    if (params.joblist == "NONE") {{
+        println("Usage: nextflow execute_joblist.nf  --joblist [joblist file] -c [config file]")
+        System.exit(2)
+    }}
+    lines = Channel.fromPath(params.joblist).splitText()
     execute_jobs(lines)
 }}"""
 

--- a/src/python/modules/exon_fasta_to_twobit.py
+++ b/src/python/modules/exon_fasta_to_twobit.py
@@ -163,7 +163,7 @@ class TwoBitConverter(CommandLineManager):
                 h.write(out_header + "\n" + sequences + "\n")
         # print(aggr_results)
         # aggr_results = aggr_results.encode('utf8')
-        cmd = f"faToTwoBit {tmp_path} {output}"
+        cmd = f"{self.fa2twobit} {tmp_path} {output}"
         # print(cmd)
         _ = self._exec(cmd, ERR)
         self._rm(tmp_path)

--- a/src/python/modules/integrate.py
+++ b/src/python/modules/integrate.py
@@ -1284,17 +1284,17 @@ class AnnotationIntegrator(CommandLineManager):
                 )
             prot_gzipped: bool = prot_file.endswith(".gz")
             with (
-                gzip.open(prot_file, "rb") if prot_gzipped else open(prot_file, "r")
+                gzip.open(prot_file, "rt") if prot_gzipped else open(prot_file, "r")
             ) as h:
                 prot_seqs: List[str] = self._read_fasta(h, ref)
             nuc_gzipped: bool = nuc_file.endswith(".gz")
-            with gzip.open(nuc_file, "rb") if nuc_gzipped else open(nuc_file, "r") as h:
+            with gzip.open(nuc_file, "rt") if nuc_gzipped else open(nuc_file, "r") as h:
                 nuc_seqs: List[str] = self._read_fasta(h, ref)
-            write_mode: str = "a" if seq_files_recorded else "w"
-            with open(self.protein_file, write_mode) as h:
+            gzip_mode: str = "at" if seq_files_recorded else "wt"
+            with gzip.open(self.protein_file, gzip_mode) as h:
                 for entry in prot_seqs:
                     h.write(entry + "\n")
-            with open(self.nucleotide_file, write_mode) as h:
+            with gzip.open(self.nucleotide_file, gzip_mode) as h:
                 for entry in nuc_seqs:
                     h.write(entry + "\n")
             seq_files_recorded = True
@@ -1315,7 +1315,7 @@ class AnnotationIntegrator(CommandLineManager):
                 header = ""
                 seq = ""
                 proj: str = base_proj_name(line.split()[0]).lstrip(">")
-                if proj not in self.final_projections:
+                if f"{ref}.{proj}" not in self.final_projections:
                     continue
                 header = proj
             elif header:


### PR DESCRIPTION
Found and fixed four bugs while running TOGA2 on RHEL8 (glibc 2.28) 
with three references against a query genome.

### `exon_fasta_to_twobit.py`
- **`--fatotwobit_binary` silently ignored**: Line 166 hardcodes 
  `f"faToTwoBit {tmp_path} {output}"` instead of using `self.fa2twobit`, 
  so the `--fatotwobit_binary` CLI flag has no effect at the SLEASY step. 
  Fixed to `f"{self.fa2twobit} {tmp_path} {output}"`.

### `integrate.py` (`prepare_sequence_files` / `_read_fasta`)
- **gzip read mode**: `gzip.open` was called with `"rb"` (bytes), but 
  `_read_fasta` uses `str.startswith`, causing 
  `TypeError: startswith first arg must be bytes or a tuple of bytes, not str`. 
  Fixed to `"rt"`.
- **projection lookup missing reference prefix**: `self.final_projections` 
  stores names as `"{species}.{projection}"` (e.g. `hg38.XM_011510358.3#NBAS#328`), 
  but `_read_fasta` looked up the bare projection name without the prefix — 
  so nothing ever matched and `protein.fa.gz` / `nucleotide.fa.gz` were 
  always empty. Fixed to check `f"{ref}.{proj}"`.
- **gzip write mode**: the write step used `open()` instead of `gzip.open()`, 
  producing plain-text files with a `.fa.gz` extension (invalid gzip). 
  Fixed to `gzip.open(..., "wt"/"at")`.

### `constants.py` (Nextflow template)
- **DSL2 incompatibility**: the joblist guard and `Channel.fromPath` call 
  were at the top level, which is not valid in Nextflow DSL2. Moved both 
  inside the `workflow {}` block.