### PR TITLE
Update CI workflow to pin specific pyo3 interpreters for maturin develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
         
         cd postoga/rustools
         python3 -m pip install maturin
-        maturin develop --release -i python
+        maturin develop --release -- -i python
         cd ../..
         
         ./postoga/postoga.py -h

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,157 +9,203 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
-    
+
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
-    
+
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v6
-      with:
-        submodules: recursive
-    
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
-    - name: Install Nextflow
-      uses: nf-core/setup-nextflow@v1
-    
-    - name: Install system dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y \
-          gcc \
-          g++ \
-          make \
-          wget \
-          curl \
-          git \
-          bash \
-          cargo \
-          rustc \
-          pkg-config \
-          libhdf5-dev \
-          python3-dev \
-          python3-pip \
-          python3-venv
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Check gcc version
-      run: |
-        gcc --version
-        g++ --version
-    
-    - name: Cache Rust dependencies
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          src/rust/target
-          bed2gtf/target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-
-    
-    - name: Cache Python dependencies
-      uses: actions/cache@v5
-      with:
-        path: |
-          ~/.cache/pip
-          toga2/
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-    
-    - name: Set executable permissions
-      run: |
-        chmod +x check_dependencies.py
-        chmod +x toga2.py
-        chmod +x src/python/*.py
-        chmod +x src/python/modules/*.py
-    
-    - name: Install Python packages in toga2 venv and postoga installation
-      run: |
-        if [ ! -d "toga2" ]; then
-          echo "Creating venv"
-          python3 -m venv toga2
-        fi
-        
-        source toga2/bin/activate
-        which python3
+      - name: Install Nextflow
+        uses: nf-core/setup-nextflow@v1
 
-        echo "Checking the current Python version: $(which python3)"
-        
-        python3 -m pip install --upgrade pip setuptools wheel
-        python3 -m pip install -r requirements.txt
-        
-        python3 check_dependencies.py install_third_party
-        
-        cd postoga/rustools
-        python3 -m pip install maturin
-        maturin develop --release -- -i python
-        cd ../..
-        
-        ./postoga/postoga.py -h
-    
-    - name: Install UCSC binaries
-      run: |
-        make install_binaries
-    
-    - name: Build C components
-      run: |
-        make build_c
-    
-    - name: Build Cython components
-      run: |
-        if [ ! -d "toga2" ]; then
-          python3 -m venv toga2
-        fi
-        
-        source toga2/bin/activate
-        
-        python3 -m pip install --upgrade pip setuptools wheel
-        python3 -m pip install -r requirements.txt
-        make build_cython
-    
-    - name: Build Rust components
-      run: |
-        # install rust
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-        source $HOME/.cargo/env
+      - name: Install system dependencies
+        run: |
+          set -euxo pipefail
 
-        make build_rust
-    
-    - name: Build CESAR2.0
-      run: |
-        make build_cesar
-    
-    - name: Train models in toga2 venv
-      run: |
-        source toga2/bin/activate
-        make train_models
-    
-    - name: Final integration test
-      run: |
-        if [ ! -d "toga2" ]; then
-          python3 -m venv toga2
-        fi
+          sudo apt-get update
+          sudo apt-get install -y \
+            gcc \
+            g++ \
+            make \
+            wget \
+            curl \
+            git \
+            bash \
+            pkg-config \
+            libhdf5-dev \
+            python3-dev \
+            python3-pip \
+            python3-venv
 
-        source toga2/bin/activate
-        # rm -rf bin/
-        # make
+      - name: Set up Rust
+        run: |
+          set -euxo pipefail
 
-        ./toga2.py -h
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          source "$HOME/.cargo/env"
 
-    - name: Verify build artifacts
-      run: |
-        echo "Checking if binaries exist:"
-        ls -la bin/
-        echo "Checking if shared libraries exist:"
-        ls -la src/python/modules/*.so
-        echo "Checking if Rust binaries exist:"
-        ls -la src/rust/target/release/
-        ls -la bed2gtf/target/release/
+          rustc --version
+          cargo --version
+
+      - name: Check gcc version
+        run: |
+          set -euxo pipefail
+
+          gcc --version
+          g++ --version
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            src/rust/target
+            bed2gtf/target
+            postoga/rustools/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Cache Python dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-py${{ matrix.python-version }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-py${{ matrix.python-version }}-pip-
+
+      - name: Set executable permissions
+        run: |
+          set -euxo pipefail
+
+          chmod +x check_dependencies.py
+          chmod +x toga2.py
+          chmod +x src/python/*.py
+          chmod +x src/python/modules/*.py
+
+      - name: Create toga2 venv and install Python dependencies
+        run: |
+          set -euxo pipefail
+
+          rm -rf toga2
+          python -m venv toga2
+          source toga2/bin/activate
+
+          python -VV
+          which python
+          python -c "import sys, sysconfig, platform; print(sys.executable); print(sysconfig.get_platform()); print(platform.machine())"
+
+          python -m pip install --upgrade pip setuptools wheel maturin
+          python -m pip install -r requirements.txt
+
+      - name: Install third-party dependencies
+        run: |
+          set -euxo pipefail
+
+          source toga2/bin/activate
+          python check_dependencies.py install_third_party
+
+      - name: Build and install postoga rustools
+        run: |
+          set -euxo pipefail
+
+          source toga2/bin/activate
+          source "$HOME/.cargo/env"
+
+          cd postoga/rustools
+
+          python -m pip install --upgrade maturin
+
+          env | sort | grep -E 'CARGO|PYO3|PYTHON|VIRTUAL_ENV' || true
+
+          PYO3_PYTHON="$(which python)" python -m maturin develop --release
+
+          cd ../..
+
+          ./postoga/postoga.py -h
+
+      - name: Install UCSC binaries
+        run: |
+          set -euxo pipefail
+
+          source toga2/bin/activate
+          make install_binaries
+
+      - name: Build C components
+        run: |
+          set -euxo pipefail
+
+          source toga2/bin/activate
+          make build_c
+
+      - name: Build Cython components
+        run: |
+          set -euxo pipefail
+
+          source toga2/bin/activate
+
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install -r requirements.txt
+
+          make build_cython
+
+      - name: Build Rust components
+        run: |
+          set -euxo pipefail
+
+          source toga2/bin/activate
+          source "$HOME/.cargo/env"
+
+          make build_rust
+
+      - name: Build CESAR2.0
+        run: |
+          set -euxo pipefail
+
+          source toga2/bin/activate
+          make build_cesar
+
+      - name: Train models in toga2 venv
+        run: |
+          set -euxo pipefail
+
+          source toga2/bin/activate
+          make train_models
+
+      - name: Final integration test
+        run: |
+          set -euxo pipefail
+
+          source toga2/bin/activate
+
+          ./toga2.py -h
+          ./postoga/postoga.py -h
+
+      - name: Verify build artifacts
+        run: |
+          set -euxo pipefail
+
+          echo "Checking if binaries exist:"
+          ls -la bin/
+
+          echo "Checking if shared libraries exist:"
+          ls -la src/python/modules/*.so
+
+          echo "Checking if Rust binaries exist:"
+          ls -la src/rust/target/release/
+          ls -la bed2gtf/target/release/
+
+          echo "Checking postoga rustools artifacts:"
+          ls -la postoga/rustools/target/release/ || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
         
         cd postoga/rustools
         python3 -m pip install maturin
-        maturin develop --release
+        maturin develop --release -i python
         cd ../..
         
         ./postoga/postoga.py -h


### PR DESCRIPTION
This PR includes changes to the pyo3 bindings step, directly specifying the python interpreter from the matrix test. It solves a previous bug of the CI not being able to recognize the correct python version to use:

```
⚠️  Warning: Failed to determine python platform
🔗 Found pyo3 bindings
⚠️  Warning: Failed to determine python platform
⚠️  Warning: Failed to determine python platform
💥 maturin failed
  Caused by: Unsupported Python interpreter for cross-compilation: /home/runner/work/TOGA2/TOGA2/toga2/bin/python; supported interpreters are pypy, graalpy, and python (cpython)
Error: Process completed with exit code 1.
```